### PR TITLE
Update Ember, remove ember-data, remove deprecations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,9 @@
 {
   "name": "ember-simple-auth-sample",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
@@ -13,5 +12,8 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "pretender": "0.10.0"
+  },
+  "resolutions": {
+    "ember": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-simple-auth": "~1.0.0",


### PR DESCRIPTION
I updated ember to 2.1.0, remove ember-data and remove all the deprecation in the same process.